### PR TITLE
refactor: improve game service createManyToManyData readability

### DIFF
--- a/api/game/services/game.js
+++ b/api/game/services/game.js
@@ -62,31 +62,33 @@ async function create(name, entityName) {
 }
 
 async function createManyToManyData(products) {
-  const developers = {};
-  const publishers = {};
-  const categories = {};
-  const platforms = {};
+  const developers = new Set();
+  const publishers = new Set();
+  const categories = new Set();
+  const platforms = new Set();
 
   products.forEach((product) => {
     const { developer, publisher, genres, supportedOperatingSystems } = product;
 
-    genres &&
-      genres.forEach((item) => {
-        categories[item] = true;
-      });
-    supportedOperatingSystems &&
-      supportedOperatingSystems.forEach((item) => {
-        platforms[item] = true;
-      });
-    developers[developer] = true;
-    publishers[publisher] = true;
+    genres?.forEach((item) => {
+      categories.add(item);
+    });
+
+    supportedOperatingSystems?.forEach((item) => {
+      platforms.add(item);
+    });
+
+    developers.add(developer);
+    publishers.add(publisher);
   });
 
+  const createCall = (set, entityName) => Array.from(set).map((name) => create(name, entityName));
+
   return Promise.all([
-    ...Object.keys(developers).map((name) => create(name, "developer")),
-    ...Object.keys(publishers).map((name) => create(name, "publisher")),
-    ...Object.keys(categories).map((name) => create(name, "category")),
-    ...Object.keys(platforms).map((name) => create(name, "platform")),
+    ...createCall(developers, "developer"),
+    ...createCall(publishers, "publisher"),
+    ...createCall(categories, "category"),
+    ...createCall(platforms, "platform"),
   ]);
 }
 


### PR DESCRIPTION
This PR aims to improve the readability of the `createManyToManyData` function that's inside the `games` service.

I've changed it to a better syntax by:
- using the [`Set`](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Set) object 
- changing the conditionals (`obj && obj.forEach...`) to use the [`Optional Chaining`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining).
- creating a wrapper function to make the Promise.all spreads a lot easier to read (DRY)

Thanks!