### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ In order to make it work, follow the steps:
 - With Strapi running run the following comand in your console:
 
 ```bash
-$ curl -X POST http://localhost:1337/games/populate
+$ curl -X POST http://localhost:1337/api/games/populate
 
 # you can pass query parameters like:
-$ curl -X POST http://localhost:1337/games/populate?page=2
-$ curl -X POST http://localhost:1337/games/populate?search=simcity
-$ curl -X POST http://localhost:1337/games/populate?sort=rating&price=free
-$ curl -X POST http://localhost:1337/games/populate?availability=coming&sort=popularity
+$ curl -X POST http://localhost:1337/api/games/populate?page=2
+$ curl -X POST http://localhost:1337/api/games/populate?search=simcity
+$ curl -X POST http://localhost:1337/api/games/populate?sort=rating&price=free
+$ curl -X POST http://localhost:1337/api/games/populate?availability=coming&sort=popularity
 ```
 
 ## Using dump


### PR DESCRIPTION
Estou refazendo o curso e passei uma horinha tentando rodar o `curl -X POST http://localhost:1337/games/populate` sem sucesso.

![image](https://github.com/Won-Games/api/assets/48812482/fcc01978-5a51-4514-8ada-64c54bbce60f)


Após pesquisar descobri que preciso adicionar **/api** na URL, portanto o comando que funciona é curl -X POST http://localhost:1337/api/games/populate.

Mudaram isso na versão v4:
- [Documentação da v3](https://docs-v3.strapi.io/developer-docs/latest/getting-started/quick-start.html#step-5-use-the-api)
- [Documentação da v4](https://docs.strapi.io/dev-docs/api/rest#endpoints)